### PR TITLE
Updates url format for s3 endpoint to use format that will not

### DIFF
--- a/packages/ember-uploader/lib/s3.js
+++ b/packages/ember-uploader/lib/s3.js
@@ -43,7 +43,7 @@ export default Uploader.extend({
         url = "//s3-" + json.region + ".amazonaws.com/" + json.bucket;
         delete json.region;
       } else {
-        url = "//" + json.bucket + ".s3.amazonaws.com";
+        url = "//" + ".s3.amazonaws.com/" + json.bucket;
       }
 
       var formData = self.setupFormData(file, json);


### PR DESCRIPTION
break for buckets with names including periods, e.g., 'cdn.kevy.com'
